### PR TITLE
Logging configurations

### DIFF
--- a/packages/apihandler/src/index.ts
+++ b/packages/apihandler/src/index.ts
@@ -11,6 +11,7 @@ import fetch, { Response } from 'node-fetch';
 import { GiphyService } from './giphy-service';
 import { getSecretJson } from './aws';
 import { badRequest } from './http-responses';
+import * as logger from './logger';
 
 const GIPHY_SECRET_ID = process.env.GIPHY_SECRET_ID;
 
@@ -19,11 +20,11 @@ async function giphyApiToken(): Promise<string> {
     throw new Error('GIPHY_SECRET_ID required');
   }
 
-  console.log(`getting secret from "${GIPHY_SECRET_ID}"`);
+  logger.info(`getting secret from "${GIPHY_SECRET_ID}"`);
   const secret = await getSecretJson(GIPHY_SECRET_ID);
 
   if (secret && secret.apiToken) {
-    console.log('success');
+    logger.info('success');
   }
 
   return secret.apiToken;
@@ -89,26 +90,26 @@ async function imageResult(imageResponse: Response): Promise<APIGatewayProxyResu
 }
 
 export async function handleTrending(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
-  console.log('handleTrending', event);
+  logger.info('handleTrending', event);
 
   try {
     const apiKey = await giphyApiToken();
     const giphyService = new GiphyService(apiKey);
 
-    console.log('getting trending image');
+    logger.info('getting trending image');
     const apiResponse = await giphyService.getTrending();
-    console.log('api response', apiResponse);
+    logger.info('api response', apiResponse);
     const apiResponseBody = await apiResponse.body;
-    console.log('api response body', JSON.stringify(apiResponseBody, null, 2));
+    logger.info('api response body', JSON.stringify(apiResponseBody, null, 2));
 
     const imageUrl = apiResponseBody.data[0]?.images.downsized.url;
     if (typeof imageUrl === 'undefined') {
       return errorResult('no results');
     }
 
-    console.log('fetching image', imageUrl);
+    logger.info('fetching image', imageUrl);
     const imageResponse = await fetch(imageUrl);
-    console.log('image response', imageResponse);
+    logger.info('image response', imageResponse);
 
     return imageResult(imageResponse);
   } catch (error) {
@@ -118,7 +119,7 @@ export async function handleTrending(event: APIGatewayProxyEvent): Promise<APIGa
 }
 
 export async function handleSearch(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
-  console.log('handleSearch', event);
+  logger.info('handleSearch', event);
 
   const imageName = event.pathParameters?.image;
   if (typeof imageName === 'undefined') {
@@ -127,27 +128,27 @@ export async function handleSearch(event: APIGatewayProxyEvent): Promise<APIGate
   }
 
   try {
-    console.log('parse image name', imageName);
+    logger.info('parse image name', imageName);
     const imageDetails = parseImageName(imageName);
-    console.log('image details', imageDetails);
+    logger.info('image details', imageDetails);
 
     const apiKey = await giphyApiToken();
     const giphyService = new GiphyService(apiKey);
 
-    console.log(`searching for image of "${imageDetails.basename}"`);
+    logger.info(`searching for image of "${imageDetails.basename}"`);
     const apiResponse = await giphyService.getSearch(imageDetails.basename);
-    console.log('api response', apiResponse);
+    logger.info('api response', apiResponse);
     const apiResponseBody = await apiResponse.body;
-    console.log('api response body', JSON.stringify(apiResponseBody, null, 2));
+    logger.info('api response body', JSON.stringify(apiResponseBody, null, 2));
 
     const imageUrl = apiResponseBody.data[0]?.images.downsized.url;
     if (typeof imageUrl === 'undefined') {
       return errorResult('no results');
     }
 
-    console.log('fetching image', imageUrl);
+    logger.info('fetching image', imageUrl);
     const imageResponse = await fetch(imageUrl);
-    console.log('image response', imageResponse);
+    logger.info('image response', imageResponse);
 
     return imageResult(imageResponse);
   } catch (error) {
@@ -157,7 +158,7 @@ export async function handleSearch(event: APIGatewayProxyEvent): Promise<APIGate
 }
 
 export async function handleTranslate(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
-  console.log('handleTranslate', event);
+  logger.info('handleTranslate', event);
 
   const imageName = event.pathParameters?.image;
   if (typeof imageName === 'undefined') {
@@ -166,24 +167,24 @@ export async function handleTranslate(event: APIGatewayProxyEvent): Promise<APIG
   }
 
   try {
-    console.log('parse image name', imageName);
+    logger.info('parse image name', imageName);
     const imageDetails = parseImageName(imageName);
-    console.log('image details', imageDetails);
+    logger.info('image details', imageDetails);
 
     const apiKey = await giphyApiToken();
     const giphyService = new GiphyService(apiKey);
 
-    console.log(`translating "${imageDetails.basename}" to image`);
+    logger.info(`translating "${imageDetails.basename}" to image`);
     const apiResponse = await giphyService.getTranslate(imageDetails.basename);
-    console.log('api response', apiResponse);
+    logger.info('api response', apiResponse);
     const apiResponseBody = await apiResponse.body;
-    console.log('api response body', JSON.stringify(apiResponseBody, null, 2));
+    logger.info('api response body', JSON.stringify(apiResponseBody, null, 2));
 
     const imageUrl = apiResponseBody.data.images.downsized.url;
 
-    console.log('fetching image', imageUrl);
+    logger.info('fetching image', imageUrl);
     const imageResponse = await fetch(imageUrl);
-    console.log('image response', imageResponse);
+    logger.info('image response', imageResponse);
 
     return imageResult(imageResponse);
   } catch (error) {
@@ -193,7 +194,7 @@ export async function handleTranslate(event: APIGatewayProxyEvent): Promise<APIG
 }
 
 export async function handleRandom(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
-  console.log('handleRandom', event);
+  logger.info('handleRandom', event);
 
   const imageName = event.pathParameters?.image;
   if (typeof imageName === 'undefined') {
@@ -202,24 +203,24 @@ export async function handleRandom(event: APIGatewayProxyEvent): Promise<APIGate
   }
 
   try {
-    console.log('parse image name', imageName);
+    logger.info('parse image name', imageName);
     const imageDetails = parseImageName(imageName);
-    console.log('image details', imageDetails);
+    logger.info('image details', imageDetails);
 
     const apiKey = await giphyApiToken();
     const giphyService = new GiphyService(apiKey);
 
-    console.log(`getting random image of "${imageDetails.basename}"`);
+    logger.info(`getting random image of "${imageDetails.basename}"`);
     const apiResponse = await giphyService.getRandom(imageDetails.basename);
-    console.log('api response', apiResponse);
+    logger.info('api response', apiResponse);
     const apiResponseBody = await apiResponse.body;
-    console.log('api response body', JSON.stringify(apiResponseBody, null, 2));
+    logger.info('api response body', JSON.stringify(apiResponseBody, null, 2));
 
     const imageUrl = apiResponseBody.data.images.downsized.url;
 
-    console.log('fetching image', imageUrl);
+    logger.info('fetching image', imageUrl);
     const imageResponse = await fetch(imageUrl);
-    console.log('image response', imageResponse);
+    logger.info('image response', imageResponse);
 
     return imageResult(imageResponse);
   } catch (error) {

--- a/packages/apihandler/src/logger.ts
+++ b/packages/apihandler/src/logger.ts
@@ -1,0 +1,34 @@
+export enum LogLevel {
+  INFO = 'INFO',
+  ERROR = 'ERROR',
+  OFF = 'OFF'
+}
+
+export const DEFAULT_LOG_LEVEL = LogLevel.ERROR;
+
+export function logLevel(): LogLevel {
+  const LOG_LEVEL = process.env.LOG_LEVEL;
+
+  switch (LOG_LEVEL) {
+    case LogLevel.INFO:
+      return LogLevel.INFO;
+    case LogLevel.ERROR:
+      return LogLevel.ERROR;
+    case LogLevel.OFF:
+      return LogLevel.OFF;
+    default:
+      return DEFAULT_LOG_LEVEL;
+  }
+}
+
+export function info(message?: any, ...optionalParams: any[]) {
+  if (logLevel() === LogLevel.INFO) {
+    console.info(message, ...optionalParams);
+  }
+}
+
+export function error(message?: any, ...optionalParams: any[]) {
+  if ([LogLevel.ERROR, LogLevel.INFO].includes(logLevel())) {
+    console.error(message, ...optionalParams);
+  }
+}

--- a/packages/apihandler/test/logger.test.ts
+++ b/packages/apihandler/test/logger.test.ts
@@ -1,0 +1,90 @@
+import * as logger from '../src/logger';
+
+describe('logger', () => {
+  const OLD_ENV = process.env;
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+
+  beforeEach(() => {
+    jest.resetModules(); // Most important - it clears the cache
+    process.env = { ...OLD_ENV }; // Make a copy
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV; // Restore old environment
+    errorSpy.mockClear();
+    infoSpy.mockClear();
+  });
+
+  describe('with default settings', () => {
+    describe('logLevel', () => {
+      it('is ERROR', () => {
+        expect(logger.logLevel()).toEqual(logger.LogLevel.ERROR);
+      });
+    });
+
+    describe('error', () => {
+      it('logs to standard error', () => {
+        logger.error('Something went wrong :(');
+        expect(errorSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('info', () => {
+      it('is suppressed', () => {
+        logger.info('Hello, World!');
+        expect(infoSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('log level OFF', () => {
+    describe('logLevel', () => {
+      it('is OFF', () => {
+        process.env.LOG_LEVEL = 'OFF';
+        expect(logger.logLevel()).toEqual(logger.LogLevel.OFF);
+      });
+    });
+
+    describe('error', () => {
+      it('is suppressed', () => {
+        process.env.LOG_LEVEL = 'OFF';
+        logger.error('Something went wrong :(');
+        expect(errorSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('info', () => {
+      it('is suppressed', () => {
+        process.env.LOG_LEVEL = 'OFF';
+        logger.info('Hello, World!');
+        expect(infoSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('log level INFO', () => {
+    describe('logLevel', () => {
+      it('is INFO', () => {
+        process.env.LOG_LEVEL = 'INFO';
+        expect(logger.logLevel()).toEqual(logger.LogLevel.INFO);
+      });
+    });
+
+    describe('error', () => {
+      it('logs to standard error', () => {
+        process.env.LOG_LEVEL = 'INFO';
+        logger.error('Something went wrong :(');
+        expect(errorSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('info', () => {
+      it('logs to standard out', () => {
+        process.env.LOG_LEVEL = 'INFO';
+        logger.info('Hello, World!');
+        expect(infoSpy).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/packages/infrastructure/lib/gifgen-stack.ts
+++ b/packages/infrastructure/lib/gifgen-stack.ts
@@ -63,7 +63,7 @@ export class GifGenStack extends cdk.Stack {
       timeout: cdk.Duration.seconds(60), // TODO: tune this
       environment: {
         GIPHY_SECRET_ID: secret.secretId,
-        LOG_LEVEL: props?.logLevel || LogLevel.ERROR
+        LOG_LEVEL: props?.observability?.logLevel || LogLevel.ERROR
       },
       xrayEnabled: !!props?.observability?.enableTracing,
       xrayLogLevel: props?.observability?.logLevel && toXrayLogLevel(props.observability.logLevel)

--- a/packages/infrastructure/lib/gifgen-stack.ts
+++ b/packages/infrastructure/lib/gifgen-stack.ts
@@ -62,7 +62,8 @@ export class GifGenStack extends cdk.Stack {
       memorySize: 1024, // TODO: tune this
       timeout: cdk.Duration.seconds(60), // TODO: tune this
       environment: {
-        GIPHY_SECRET_ID: secret.secretId
+        GIPHY_SECRET_ID: secret.secretId,
+        LOG_LEVEL: props?.logLevel || LogLevel.ERROR
       },
       xrayEnabled: !!props?.observability?.enableTracing,
       xrayLogLevel: props?.observability?.logLevel && toXrayLogLevel(props.observability.logLevel)

--- a/packages/infrastructure/test/gifgen-stack.test.ts
+++ b/packages/infrastructure/test/gifgen-stack.test.ts
@@ -62,6 +62,7 @@ describe('GifGenStack', () => {
           },
           Environment: {
             Variables: {
+              LOG_LEVEL: 'INFO',
               AWS_XRAY_LOG_LEVEL: 'info'
             }
           }


### PR DESCRIPTION
Support log level configurations so that logging can be configured differently per environment (for example: to suppress info messages during tests, but enable error and info messages in prod).